### PR TITLE
iOS GPS location missing fix

### DIFF
--- a/Naxam.Mapbox.Platform.iOS/MapViewRenderer.cs
+++ b/Naxam.Mapbox.Platform.iOS/MapViewRenderer.cs
@@ -1183,7 +1183,7 @@ namespace Naxam.Controls.Mapbox.Platform.iOS
         [Export("mapView:didUpdateUserLocation:")]
         public void MapViewDidUpdateUserLocation(MGLMapView mapView, MGLUserLocation userLocation)
         {
-            if (userLocation != null)
+            if (userLocation?.Location?.Coordinate != null)
             {
                 Element.UserLocation = new Position(
                     userLocation.Location.Coordinate.Latitude,


### PR DESCRIPTION
This fixes a null ref on iOS when GPS location is missing. 